### PR TITLE
Changes to fix widget leaks and linting

### DIFF
--- a/src/ndv/viewer/_backends/_protocols.py
+++ b/src/ndv/viewer/_backends/_protocols.py
@@ -110,10 +110,10 @@ class PCanvas(Protocol):
     ) -> tuple[float, float, float]:
         """Map XY canvas position (pixels) to XYZ coordinate in world space."""
 
-    def elements_at(self, pos_xy: Sequence[float]) -> list[CanvasElement]: ...
+    def elements_at(self, pos_xy: tuple[float, float]) -> list[CanvasElement]: ...
     def add_roi(
         self,
-        vertices: Sequence[Sequence[float]] | None = ...,
-        color: Any = ...,
-        border_color: Any | None = ...,
+        vertices: Sequence[tuple[float, float]] | None = None,
+        color: cmap.Color | None = None,
+        border_color: cmap.Color | None = None,
     ) -> PRoiHandle: ...

--- a/src/ndv/viewer/_backends/_pygfx.py
+++ b/src/ndv/viewer/_backends/_pygfx.py
@@ -16,7 +16,6 @@ if TYPE_CHECKING:
 
     from pygfx.materials import ImageBasicMaterial
     from pygfx.resources import Texture
-    from qtpy.QtCore import QEvent
     from qtpy.QtWidgets import QWidget
 
     from ._protocols import CanvasElement
@@ -399,21 +398,25 @@ class RectangularROIHandle(PyGFXRoiHandle):
 class _QWgpuCanvas(QWgpuCanvas):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-        self._sup_mouse_event = self._subwidget._mouse_event
-        self._subwidget._mouse_event = self._mouse_event
-        self._filter: Any | None = None
+        # self._sup_mouse_event = self._subwidget._mouse_event
+        # self._subwidget._mouse_event = self._mouse_event
+
+    def installEventFilter(self, filter: Any) -> None:
+        print("installing filter")
+        super().installEventFilter(filter)
+        self._subwidget.installEventFilter(filter)
 
     def sizeHint(self) -> QSize:
         return QSize(512, 512)
 
-    def installEventFilter(self, filter: Any) -> None:
-        self._filter = filter
-
-    def _mouse_event(
-        self, event_type: str, event: QEvent, *args: Any, **kwargs: Any
-    ) -> None:
-        if self._filter and not self._filter.eventFilter(self, event):
-            self._sup_mouse_event(event_type, event, *args, **kwargs)
+    # def _mouse_event(
+    #     self, event_type: str, event: QEvent, *args: Any, **kwargs: Any
+    # ) -> None:
+    #     breakpoint()
+    #     self.eventFilter()
+    #     ...
+    #     # if self._filter and not self._filter.eventFilter(self, event):
+    #     #     self._sup_mouse_event(event_type, event, *args, **kwargs)
 
 
 class PyGFXViewerCanvas:

--- a/src/ndv/viewer/_backends/_vispy.py
+++ b/src/ndv/viewer/_backends/_vispy.py
@@ -15,6 +15,8 @@ from vispy import scene
 from vispy.color import Color
 from vispy.util.quaternion import Quaternion
 
+from ._protocols import PCanvas
+
 if TYPE_CHECKING:
     from typing import Callable, Sequence
 
@@ -435,7 +437,7 @@ class VispyRoiHandle:
         return self._roi.cursor_at(pos)
 
 
-class VispyViewerCanvas:
+class VispyViewerCanvas(PCanvas):
     """Vispy-based viewer for data.
 
     All vispy-specific code is encapsulated in this class (and non-vispy canvases
@@ -443,7 +445,7 @@ class VispyViewerCanvas:
     """
 
     def __init__(self) -> None:
-        self._canvas = scene.SceneCanvas()
+        self._canvas = scene.SceneCanvas(size=(600, 600))
         self._current_shape: tuple[int, ...] = ()
         self._last_state: dict[Literal[2, 3], Any] = {}
 
@@ -521,9 +523,9 @@ class VispyViewerCanvas:
 
     def add_roi(
         self,
-        vertices: list[tuple[float, float]] | None = None,
-        color: Any | None = None,
-        border_color: Any | None = None,
+        vertices: Sequence[tuple[float, float]] | None = None,
+        color: cmap.Color | None = None,
+        border_color: cmap.Color | None = None,
     ) -> VispyRoiHandle:
         """Add a new Rectangular ROI node to the scene."""
         roi = RectangularROI(parent=self._view.scene)
@@ -569,9 +571,9 @@ class VispyViewerCanvas:
         """Map XY canvas position (pixels) to XYZ coordinate in world space."""
         return self._view.scene.transform.imap(pos_xy)[:3]  # type: ignore [no-any-return]
 
-    def elements_at(self, pos_xy: tuple[float, float, float]) -> list[CanvasElement]:
+    def elements_at(self, pos_xy: tuple[float, float]) -> list[CanvasElement]:
         elements = []
-        visuals = self._canvas.visuals_at(pos_xy[:2])
+        visuals = self._canvas.visuals_at(pos_xy)
         for vis in visuals:
             if (handle := self._elements.get(vis)) is not None:
                 elements.append(handle)

--- a/src/ndv/viewer/_viewer.py
+++ b/src/ndv/viewer/_viewer.py
@@ -607,7 +607,7 @@ class NDViewer(QWidget):
         # the backend widget.
         intercept = False
         # use children in case backend has a subwidget stealing events.
-        if obj in self._qcanvas.children():
+        if obj is self._qcanvas or obj in (self._qcanvas.children()):
             if isinstance(event, QMouseEvent):
                 intercept |= self._canvas_mouse_event(event)
             if event.type() == QEvent.Type.KeyPress:

--- a/src/ndv/viewer/_viewer.py
+++ b/src/ndv/viewer/_viewer.py
@@ -606,7 +606,8 @@ class NDViewer(QWidget):
         # to the canvas. Return `True` to prevent the event from being passed to
         # the backend widget.
         intercept = False
-        if obj is self._qcanvas:
+        # use children in case backend has a subwidget stealing events.
+        if obj in self._qcanvas.children():
             if isinstance(event, QMouseEvent):
                 intercept |= self._canvas_mouse_event(event)
             if event.type() == QEvent.Type.KeyPress:


### PR DESCRIPTION
hey @gselzer, I noticed that tests were failing on macos due to widget leaks, and (while it's annoying) it turns out to be due to the storage of methods (bound to self) in the callback lists like `self._on_mouse_press`.  So, in this branch I remove those.  I do generally like the concept of dynamic mouse callbacks, but it's tricky in general to retain pointers to callbacks in a way that doesn't mess up cleanup (turned out to be a lot of work in psygnal to do that safely).  So, while how I have it here is less extensible, it's a bit easier to follow the logic for now and we can revisit that dynamic concept in the future.

Similarly, in the pygfx backend, retaining a pointer to `self._filter` was also preventing proper cleanup.  I found a method that uses less code and cleans up better